### PR TITLE
Update fs-extra / wiredep for Node 6 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "homepage": "https://github.com/andre-meier/broccoli-wiredependencies",
   "dependencies": {
     "broccoli-writer": "^0.1.1",
-    "fs-extra": "^0.18.3",
-    "wiredep": "^2.2.2"
+    "fs-extra": "^0.30.0",
+    "wiredep": "^3.0.1"
   },
   "devDependencies": {
     "lodash-node": "^3.9.1"


### PR DESCRIPTION
This allows usage with graceful-fs@4.

The fs-extra version is relatively arbitrary in that it has no major deprecations, unlike the 1.0 release, but the actual minimum version we need is 0.21.0.

The wiredep 3.0 version has some breaking changes, but they should not affect the usage in this package, because we don't use the special bower html comments (I did some manual testing).